### PR TITLE
event handler returns user id 0

### DIFF
--- a/zoom_sdk_c_sharp_wrap/meeting_audio_dotnet_wrap.cpp
+++ b/zoom_sdk_c_sharp_wrap/meeting_audio_dotnet_wrap.cpp
@@ -16,7 +16,7 @@ namespace ZOOM_SDK_DOTNET_WRAP {
 		virtual unsigned int GetUserId()
 		{
 			if (m_pStatus)
-				m_pStatus->GetUserId();
+				return (unsigned int)m_pStatus->GetUserId();
 			return 0;
 		}
 


### PR DESCRIPTION
I did test and create forum question for this, https://devforum.zoom.us/t/c-wrapper-onuseraudiostatuschange-event-problem/20809 "C# wrapper onUserAudioStatusChange event problem", but found the solution. It works on my sample test project fine.