### PR TITLE
Fix audio device change events never being called

### DIFF
--- a/zoom_sdk_c_sharp_wrap/setting_service_dotnet_wrap.cpp
+++ b/zoom_sdk_c_sharp_wrap/setting_service_dotnet_wrap.cpp
@@ -33,6 +33,11 @@ namespace ZOOM_SDK_DOTNET_WRAP {
 
 	IAudioSettingContextDotNetWrap^ CSettingServiceDotNetWrap::GetAudioSettings()
 	{
+		if (CAudioSettingContextDotNetWrap::Instance)
+		{
+			CAudioSettingContextDotNetWrap::Instance->BindEvent();
+		}
+
 		return CAudioSettingContextDotNetWrap::Instance;
 	}
 


### PR DESCRIPTION
Add_CB_onComputerMicDeviceChanged(...)
Add_CB_onComputerSpeakerDeviceChanged(...)

Do not work because events are not binded when audio settings context is built. Specified callbacks are never called.

This PR calls BindEvent on GetAudioSettings to correctly hook up SDK events.